### PR TITLE
Every call with a token id is now processed in order to add the mangogenerated user_id to it before being sent to modules' backends

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -545,6 +545,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
+    },
     "babel-cli": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
@@ -2447,6 +2456,24 @@
       "integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
+      "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -3405,8 +3432,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
       "version": "1.1.4",

--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,7 @@
     "apollo-link-context": "^1.0.9",
     "apollo-link-http": "^1.5.5",
     "apollo-server-express": "^2.1.0",
+    "axios": "^0.18.0",
     "cors": "^2.8.4",
     "dotenv": "^6.1.0",
     "express": "^4.16.3",

--- a/server/src/createRemoteSchema.js
+++ b/server/src/createRemoteSchema.js
@@ -26,7 +26,8 @@ export const createRemoteSchema = async (uri) => {
     return (
       {
         headers: {
-          Authorization: previousContext.graphqlContext.headers.authorization ? previousContext.graphqlContext.headers.authorization : ''
+          Authorization: previousContext.graphqlContext.headers.authorization ? previousContext.graphqlContext.headers.authorization : '',
+          UserId: previousContext.graphqlContext.headers.userId ? previousContext.graphqlContext.headers.userId : ''
         }
       }
     )

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -5,10 +5,33 @@ import { ApolloServer, ForbiddenError } from 'apollo-server-express'
 import { mergeSchemas } from 'graphql-tools'
 import jwt from 'express-jwt'
 import jwksRsa from 'jwks-rsa'
+import axios from 'axios'
 
 import { createTransformedRemoteSchema } from './createRemoteSchema'
 import { teams } from './links'
 import logger from './logger'
+
+async function getUserId (authId) {
+  try {
+    const userDate = await axios({
+      url: process.env.USERS_API_URL,
+      method: 'post',
+      data: {
+        query: `
+        {
+          userByAuthId(authId: "${authId}")
+          {
+            id
+          }
+        }
+        `
+      }
+    })
+    return userDate.data.data.userByAuthId.id
+  } catch (error) {
+    return (error)
+  }
+}
 
 async function run () {
   const transformedTeamsSchema = await createTransformedRemoteSchema('teams_', process.env.TEAMS_API_URL)
@@ -47,7 +70,6 @@ async function run () {
   }
 }
 `
-
   const app = express()
 
   app.use('/graphql',
@@ -71,11 +93,32 @@ async function run () {
     }
   )
 
+  app.use('/graphql', (req, res, next) => {
+    res.locals.userId = 'haha'
+    if (req.user) {
+      getUserId(req.user.sub)
+        .then(data => {
+          res.locals.userId = data
+          next()
+        })
+        .catch(err => {
+          res.locals.error = err
+          next()
+        })
+    }
+  })
+
   const context = ({ req, res }) => {
     if (res.locals.error) {
       throw new ForbiddenError(res.locals.error)
     }
-    return req
+    const response = {
+      headers: Object.assign(
+        res.locals.userId ? { userId: res.locals.userId } : {},
+        req.headers.authorization ? { authorization: req.headers.authorization } : {}
+      )
+    }
+    return response
   }
 
   const server = new ApolloServer({

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -65,15 +65,15 @@ async function run () {
     }),
     function (err, req, res, next) {
       if (err.code === 'invalid_token') {
-        res.error = err.message
+        res.locals.error = err.message
       }
       return next()
     }
   )
 
   const context = ({ req, res }) => {
-    if (res.error) {
-      throw new ForbiddenError(res.error)
+    if (res.locals.error) {
+      throw new ForbiddenError(res.locals.error)
     }
     return req
   }

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -94,7 +94,7 @@ async function run () {
   )
 
   app.use('/graphql', (req, res, next) => {
-    res.locals.userId = 'haha'
+    res.locals.userId = ''
     if (req.user) {
       getUserId(req.user.sub)
         .then(data => {
@@ -105,6 +105,8 @@ async function run () {
           res.locals.error = err
           next()
         })
+    } else {
+      next()
     }
   })
 


### PR DESCRIPTION
For now, the token is still forwarded, yet we should stop using it as soon as possible.

The user_id is accessible in req.headers.userid 